### PR TITLE
Move package-tracker to different organisation

### DIFF
--- a/CMLibStorage.cmake
+++ b/CMLibStorage.cmake
@@ -1,3 +1,3 @@
 SET(STORAGE_LIST DEP)
 
-SET(STORAGE_LIST_DEP "https://github.com/bringauto/package-tracker.git")
+SET(STORAGE_LIST_DEP "https://github.com/bacpack-system/package-tracker.git")

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,6 +1,6 @@
 SET(CMAKE_FIND_USE_CMAKE_SYSTEM_PATH FALSE)
 
-BA_PACKAGE_LIBRARY(fleet-protocol-interface v2.0.0 PLATFORM_STRING_MODE any_machine NO_DEBUG ON)
+BA_PACKAGE_LIBRARY(fleet-protocol-interface v2.0.0 NO_DEBUG ON)
 BA_PACKAGE_LIBRARY(fleet-protocol-cpp       v1.1.1)
 BA_PACKAGE_LIBRARY(protobuf                 v4.21.12)
 BA_PACKAGE_LIBRARY(zlib                     v1.2.11)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,9 +1,9 @@
 SET(CMAKE_FIND_USE_CMAKE_SYSTEM_PATH FALSE)
 
-BA_PACKAGE_LIBRARY(fleet-protocol-interface             v2.0.0 PLATFORM_STRING_MODE any_machine NO_DEBUG ON)
-BA_PACKAGE_LIBRARY(fleet-protocol-cxx-helpers-static    v1.1.1)
-BA_PACKAGE_LIBRARY(protobuf      v4.21.12)
-BA_PACKAGE_LIBRARY(zlib          v1.2.11)
+BA_PACKAGE_LIBRARY(fleet-protocol-interface v2.0.0 PLATFORM_STRING_MODE any_machine NO_DEBUG ON)
+BA_PACKAGE_LIBRARY(fleet-protocol-cpp       v1.1.1)
+BA_PACKAGE_LIBRARY(protobuf                 v4.21.12)
+BA_PACKAGE_LIBRARY(zlib                     v1.2.11)
 
 IF (FLEET_PROTOCOL_BUILD_EXTERNAL_SERVER)
     BA_PACKAGE_LIBRARY(fleet-http-client-shared v1.5.0)


### PR DESCRIPTION
- [x] Change package tracker url
- [x] Update fleet-protocol-cxx-helpers name
- [x] Remove any_machine flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the repository URL for a dependency tracker to ensure the application uses the most current external resources.
  - Refined key dependency configurations for protocol libraries, enhancing overall consistency and reliability across systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->